### PR TITLE
parser for the item and collection ids

### DIFF
--- a/cmems_stac/conventions/collection.py
+++ b/cmems_stac/conventions/collection.py
@@ -1,4 +1,5 @@
 import re
+from dataclasses import dataclass
 
 mfc_id = re.compile(
     r"""
@@ -37,3 +38,43 @@ old_tac_id = re.compile(
     """,
     flags=re.VERBOSE,
 )
+
+
+@dataclass(frozen=True)
+class MFCCollectionId:
+    geographical_area: str
+    product_type: str
+    thematic: str
+    complementary_info: str | None
+    center_ranking: str
+    center_id: str
+
+    @classmethod
+    def from_string(cls, string):
+        match = mfc_id.fullmatch(string)
+        if match is None:
+            raise ValueError(f"invalid model and forecasting center ID: {string}")
+
+        return cls(**match.groupdict())
+
+
+@dataclass(frozen=True)
+class TACCollectionId:
+    observation_type: str
+    geographical_area: str
+    thematic: str | None
+    complementary_info: str | None
+    kind_product: str
+    product_type: str
+    center_ranking: str
+    center_id: str
+
+    @classmethod
+    def from_string(cls, string):
+        match = tac_id.fullmatch(string) or old_tac_id.fullmatch(string)
+        if match is None:
+            raise ValueError(f"invalid thematic assembly center ID: {string}")
+
+        parts = match.groupdict()
+        parts.setdefault("thematic", "PHY")
+        return cls(**parts)

--- a/cmems_stac/conventions/collection.py
+++ b/cmems_stac/conventions/collection.py
@@ -78,3 +78,13 @@ class TACCollectionId:
         parts = match.groupdict()
         parts.setdefault("thematic", "PHY")
         return cls(**parts)
+
+
+def parse_collection_id(string):
+    for cls in [MFCCollectionId, TACCollectionId]:
+        try:
+            return cls.from_string(string)
+        except ValueError:
+            pass
+
+    raise ValueError(f"unknown collection id format: {string}")

--- a/cmems_stac/conventions/collection.py
+++ b/cmems_stac/conventions/collection.py
@@ -1,0 +1,39 @@
+import re
+
+mfc_id = re.compile(
+    r"""
+    (?P<geographical_area>[A-Z]+)
+    _(?P<product_type>[A-Z]+)
+    _(?P<thematic>[A-Z]+)
+    (?:_(?P<complementary_info>[A-Z]+))?
+    _(?P<center_ranking>[0-9]{3})
+    _(?P<center_id>[0-9]{3})
+    """,
+    flags=re.VERBOSE,
+)
+tac_id = re.compile(
+    r"""
+    (?P<observation_type>[A-Z]+)
+    _(?P<geographical_area>[A-Z]+)
+    _(?P<thematic>[A-Z]+)
+    (?:_(?P<complementary_info>[A-Z]+))??
+    _(?P<kind_product>[A-Z0-9]+)
+    _(?P<product_type>[A-Z]+)
+    _(?P<center_ranking>[0-9]{3})
+    _(?P<center_id>[0-9]{3})
+    """,
+    flags=re.VERBOSE,
+)
+old_tac_id = re.compile(
+    r"""
+    (?P<observation_type>[A-Z]+)
+    _(?P<geographical_area>[A-Z]+)
+    _(?P=observation_type)
+    _(?P<kind_product>[A-Z0-9]+)
+    _(?P<product_type>[A-Z]+)
+    _(?P<complementary_info>[A-Z]+)
+    _(?P<center_ranking>[0-9]{3})
+    _(?P<center_id>[0-9]{3})
+    """,
+    flags=re.VERBOSE,
+)

--- a/cmems_stac/conventions/item.py
+++ b/cmems_stac/conventions/item.py
@@ -1,0 +1,24 @@
+import re
+
+id_ = re.compile(
+    r"""
+    (?P<origin>[a-z0-9]+)
+    _(?P<group>[a-z]+)
+    (?:-(?P<pc>[a-z]+))?
+    _(?P<area>[a-z]+)
+    _(?P<thematic>[a-z]+)
+    (?:-(?P<var>[a-z]+))?
+    _(?P<type>[a-z]+)
+    (?:_(?P<complementary_info>(?:
+        -?[a-z]+(?#complementary info)
+        |-?[0-9.]+km|0\.25deg|hr (?#spatial resolution)
+        |-?[a-z0-9]+  (?#data level)
+        |-?[a-zA-Z0-9]+(?#platform)
+        |-?[a-z]+  (?#insitu data type)
+        |-?[0-9]D  (?#number of spatial dimensions)
+    )+))?
+    _(?P<temporal_resolution>[A-Z0-9a-z.]{3,})
+    (?:-(?P<typology>[im]))?
+    """,
+    flags=re.VERBOSE,
+)

--- a/cmems_stac/conventions/item.py
+++ b/cmems_stac/conventions/item.py
@@ -9,14 +9,7 @@ id_ = re.compile(
     _(?P<thematic>[a-z]+)
     (?:-(?P<var>[a-z]+))?
     _(?P<type>[a-z]+)
-    (?:_(?P<complementary_info>(?:
-        -?[a-z]+(?#complementary info)
-        |-?[0-9.]+km|0\.25deg|hr (?#spatial resolution)
-        |-?[a-z0-9]+  (?#data level)
-        |-?[a-zA-Z0-9]+(?#platform)
-        |-?[a-z]+  (?#insitu data type)
-        |-?[0-9]D  (?#number of spatial dimensions)
-    )+))?
+    (?:_(?P<complementary_info>[^_]+))
     _(?P<temporal_resolution>[A-Z0-9a-z.]{3,})
     (?:-(?P<typology>[im]))?
     """,

--- a/cmems_stac/conventions/item.py
+++ b/cmems_stac/conventions/item.py
@@ -7,8 +7,8 @@ id_ = re.compile(
     (?:-(?P<pc>[a-z]+))?
     _(?P<area>[a-z]+)
     _(?P<thematic>[a-z]+)
-    (?:-(?P<var>[a-z]+))?
-    _(?P<type>[a-z]+)
+    (?:-(?P<var>[-a-z0-9]+))?
+    (?:_(?P<type>[a-z]+))
     (?:_(?P<complementary_info>[^_]+))
     _(?P<temporal_resolution>[A-Z0-9a-z.]{3,})
     (?:-(?P<typology>[im]))?


### PR DESCRIPTION
In order to allow querying variables, we need to figure out the differences between the different items. The ids on both collections and items contain a lot of the information we need; unfortunately, they are somewhat inconsistent. So in the end we might have to use the `cube:variables` and `cube:dimensions` properties instead.